### PR TITLE
Fix if block insert location

### DIFF
--- a/dist/src/dom/nodes/ViewNode.d.ts
+++ b/dist/src/dom/nodes/ViewNode.d.ts
@@ -38,6 +38,8 @@ export default class ViewNode {
     addEventListener(event: any, handler: any): void;
     removeEventListener(event: any, handler: any): void;
     dispatchEvent(event: EventData): void;
+    onInsertedChild(childNode: ViewNode, index: number): void;
+    onRemovedChild(childNode: ViewNode): void;
     insertBefore(childNode: any, referenceNode: any): void;
     appendChild(childNode: any): void;
     removeChild(childNode: any): void;

--- a/dist/src/dom/nodes/ViewNode.js
+++ b/dist/src/dom/nodes/ViewNode.js
@@ -1,7 +1,6 @@
 import { isAndroid, isIOS } from 'tns-core-modules/platform';
 import { isBoolean } from 'tns-core-modules/utils/types';
 import { getViewMeta, normalizeElementName } from '../element-registry';
-import { insertChild, removeChild } from '../utils';
 const XML_ATTRIBUTES = Object.freeze(['tap', 'style', 'rows', 'columns', 'fontAttributes']);
 export default class ViewNode {
     constructor() {
@@ -141,6 +140,8 @@ export default class ViewNode {
             this.nativeView.notify(event);
         }
     }
+    onInsertedChild(childNode, index) { }
+    onRemovedChild(childNode) { }
     insertBefore(childNode, referenceNode) {
         if (!childNode) {
             throw new Error(`Can't insert child.`);
@@ -170,7 +171,7 @@ export default class ViewNode {
         this.childNodes[index - 1].nextSibling = childNode;
         referenceNode.prevSibling = childNode;
         this.childNodes.splice(index, 0, childNode);
-        insertChild(this, childNode, index);
+        this.onInsertedChild(childNode, index);
     }
     appendChild(childNode) {
         if (!childNode) {
@@ -192,7 +193,7 @@ export default class ViewNode {
             this.lastChild.nextSibling = childNode;
         }
         this.childNodes.push(childNode);
-        insertChild(this, childNode, this.childNodes.length - 1);
+        this.onInsertedChild(childNode, this.childNodes.length - 1);
     }
     removeChild(childNode) {
         if (!childNode) {
@@ -217,7 +218,7 @@ export default class ViewNode {
         // childNode.prevSibling = null;
         // childNode.nextSibling = null;
         this.childNodes = this.childNodes.filter((node) => node !== childNode);
-        removeChild(this, childNode);
+        this.onRemovedChild(childNode);
     }
     firstElement() {
         for (var child of this.childNodes) {

--- a/dist/src/dom/utils.d.ts
+++ b/dist/src/dom/utils.d.ts
@@ -1,6 +1,3 @@
-import ViewNode from './nodes/ViewNode';
 export declare function isView(view: any): boolean;
 export declare function isLayout(view: any): boolean;
 export declare function isContentView(view: any): boolean;
-export declare function insertChild(parentNode: ViewNode, childNode: ViewNode, atIndex?: number): any;
-export declare function removeChild(parentNode: any, childNode: any): any;

--- a/dist/src/dom/utils.js
+++ b/dist/src/dom/utils.js
@@ -1,7 +1,6 @@
 import { ContentView } from 'tns-core-modules/ui/content-view';
 import { View } from 'tns-core-modules/ui/core/view';
 import { LayoutBase } from 'tns-core-modules/ui/layouts/layout-base';
-import NativeElementNode from './native/NativeElementNode';
 export function isView(view) {
     return view instanceof View;
 }
@@ -10,74 +9,4 @@ export function isLayout(view) {
 }
 export function isContentView(view) {
     return view instanceof ContentView;
-}
-export function insertChild(parentNode, childNode, atIndex = -1) {
-    if (!parentNode) {
-        return;
-    }
-    if (parentNode.meta && typeof parentNode.meta.insertChild === 'function') {
-        return parentNode.meta.insertChild(parentNode, childNode, atIndex);
-    }
-    if (!parentNode.nativeView || !childNode.nativeView) {
-        return;
-    }
-    const parentView = parentNode.nativeView;
-    const childView = childNode.nativeView;
-    //use the builder logic if we aren't being dynamic, to catch config items like <actionbar> that are not likely to be toggled
-    if (atIndex < 0 && parentView._addChildFromBuilder) {
-        parentView._addChildFromBuilder(childNode._nativeView.constructor.name, childView);
-        return;
-    }
-    if (parentView instanceof LayoutBase) {
-        if (atIndex >= 0) {
-            // our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
-            // we recalculate the index required for the insert operation buy only including native element nodes in the count
-            //our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
-            //we recalculate the index required for the insert operation buy only including native element nodes in the count
-            let nativeIndex = parentNode.childNodes.filter((e) => e instanceof NativeElementNode).indexOf(childNode);
-            parentView.insertChild(childView, nativeIndex);
-        }
-        else {
-            parentView.addChild(childView);
-        }
-        return;
-    }
-    if (parentView && parentView._addChildFromBuilder) {
-        return parentView._addChildFromBuilder(childNode._nativeView.constructor.name, childView);
-    }
-    if (parentView instanceof ContentView) {
-        parentView.content = childView;
-        return;
-    }
-    throw new Error("Parent can't contain children: " + parentNode + ', ' + childNode);
-}
-export function removeChild(parentNode, childNode) {
-    if (!parentNode) {
-        return;
-    }
-    if (parentNode.meta && typeof parentNode.meta.removeChild === 'function') {
-        return parentNode.meta.removeChild(parentNode, childNode);
-    }
-    if (!childNode.nativeView || !parentNode.nativeView) {
-        return;
-    }
-    const parentView = parentNode.nativeView;
-    const childView = childNode.nativeView;
-    if (parentView instanceof LayoutBase) {
-        parentView.removeChild(childView);
-    }
-    else if (parentView instanceof ContentView) {
-        if (parentView.content === childView) {
-            parentView.content = null;
-        }
-        if (childNode.nodeType === 8) {
-            parentView._removeView(childView);
-        }
-    }
-    else if (isView(parentView)) {
-        parentView._removeView(childView);
-    }
-    else {
-        // throw new Error("Unknown parent type: " + parent);
-    }
 }

--- a/dist/src/dom/utils.js
+++ b/dist/src/dom/utils.js
@@ -1,6 +1,7 @@
 import { ContentView } from 'tns-core-modules/ui/content-view';
 import { View } from 'tns-core-modules/ui/core/view';
 import { LayoutBase } from 'tns-core-modules/ui/layouts/layout-base';
+import NativeElementNode from './native/NativeElementNode';
 export function isView(view) {
     return view instanceof View;
 }
@@ -29,15 +30,12 @@ export function insertChild(parentNode, childNode, atIndex = -1) {
     }
     if (parentView instanceof LayoutBase) {
         if (atIndex >= 0) {
+            // our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
+            // we recalculate the index required for the insert operation buy only including native element nodes in the count
             //our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
             //we recalculate the index required for the insert operation buy only including native element nodes in the count
-            // let nativeIndex = parentNode.childNodes
-            //     .filter((e) => {
-            //         const instance = e instanceOf ElementNode';
-            //         return instance;
-            //     })
-            //     .indexOf(childNode);
-            parentView.insertChild(childView, atIndex);
+            let nativeIndex = parentNode.childNodes.filter((e) => e instanceof NativeElementNode).indexOf(childNode);
+            parentView.insertChild(childView, nativeIndex);
         }
         else {
             parentView.addChild(childView);

--- a/src/dom/nodes/ViewNode.ts
+++ b/src/dom/nodes/ViewNode.ts
@@ -3,7 +3,6 @@ import { EventData } from 'tns-core-modules/ui/page/page';
 import { isBoolean } from 'tns-core-modules/utils/types';
 
 import { getViewMeta, normalizeElementName } from '../element-registry';
-import { insertChild, removeChild } from '../utils';
 
 const XML_ATTRIBUTES = Object.freeze(['tap', 'style', 'rows', 'columns', 'fontAttributes']);
 
@@ -191,6 +190,10 @@ export default class ViewNode {
         }
     }
 
+    onInsertedChild(childNode: ViewNode, index: number) {}
+
+    onRemovedChild(childNode: ViewNode) {}
+
     insertBefore(childNode, referenceNode) {
         if (!childNode) {
             throw new Error(`Can't insert child.`);
@@ -227,7 +230,7 @@ export default class ViewNode {
         referenceNode.prevSibling = childNode;
         this.childNodes.splice(index, 0, childNode);
 
-        insertChild(this, childNode, index);
+        this.onInsertedChild(childNode, index);
     }
 
     appendChild(childNode) {
@@ -256,7 +259,7 @@ export default class ViewNode {
 
         this.childNodes.push(childNode);
 
-        insertChild(this, childNode, this.childNodes.length - 1);
+        this.onInsertedChild(childNode, this.childNodes.length - 1);
     }
 
     removeChild(childNode) {
@@ -290,7 +293,7 @@ export default class ViewNode {
 
         this.childNodes = this.childNodes.filter((node) => node !== childNode);
 
-        removeChild(this, childNode);
+        this.onRemovedChild(childNode);
     }
 
     firstElement() {

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -2,9 +2,6 @@ import { ContentView } from 'tns-core-modules/ui/content-view';
 import { View } from 'tns-core-modules/ui/core/view';
 import { LayoutBase } from 'tns-core-modules/ui/layouts/layout-base';
 
-import NativeElementNode from './native/NativeElementNode';
-import ViewNode from './nodes/ViewNode';
-
 export function isView(view) {
     return view instanceof View;
 }
@@ -15,84 +12,4 @@ export function isLayout(view) {
 
 export function isContentView(view) {
     return view instanceof ContentView;
-}
-
-export function insertChild(parentNode: ViewNode, childNode: ViewNode, atIndex = -1) {
-    if (!parentNode) {
-        return;
-    }
-
-    if (parentNode.meta && typeof parentNode.meta.insertChild === 'function') {
-        return parentNode.meta.insertChild(parentNode, childNode, atIndex);
-    }
-
-    if (!parentNode.nativeView || !childNode.nativeView) {
-        return;
-    }
-
-    const parentView = parentNode.nativeView;
-    const childView = childNode.nativeView;
-
-    //use the builder logic if we aren't being dynamic, to catch config items like <actionbar> that are not likely to be toggled
-    if (atIndex < 0 && (parentView as any)._addChildFromBuilder) {
-        (parentView as any)._addChildFromBuilder(childNode._nativeView.constructor.name, childView);
-        return;
-    }
-
-    if (parentView instanceof LayoutBase) {
-        if (atIndex >= 0) {
-            // our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
-            // we recalculate the index required for the insert operation buy only including native element nodes in the count
-            //our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
-            //we recalculate the index required for the insert operation buy only including native element nodes in the count
-            let nativeIndex = parentNode.childNodes.filter((e) => e instanceof NativeElementNode).indexOf(childNode);
-            parentView.insertChild(childView, nativeIndex);
-        } else {
-            parentView.addChild(childView);
-        }
-        return;
-    }
-
-    if (parentView && (parentView as any)._addChildFromBuilder) {
-        return (parentView as any)._addChildFromBuilder(childNode._nativeView.constructor.name, childView);
-    }
-
-    if (parentView instanceof ContentView) {
-        parentView.content = childView;
-        return;
-    }
-
-    throw new Error("Parent can't contain children: " + parentNode + ', ' + childNode);
-}
-
-export function removeChild(parentNode, childNode) {
-    if (!parentNode) {
-        return;
-    }
-
-    if (parentNode.meta && typeof parentNode.meta.removeChild === 'function') {
-        return parentNode.meta.removeChild(parentNode, childNode);
-    }
-
-    if (!childNode.nativeView || !parentNode.nativeView) {
-        return;
-    }
-
-    const parentView = parentNode.nativeView;
-    const childView = childNode.nativeView;
-
-    if (parentView instanceof LayoutBase) {
-        parentView.removeChild(childView);
-    } else if (parentView instanceof ContentView) {
-        if (parentView.content === childView) {
-            parentView.content = null;
-        }
-        if (childNode.nodeType === 8) {
-            parentView._removeView(childView);
-        }
-    } else if (isView(parentView)) {
-        parentView._removeView(childView);
-    } else {
-        // throw new Error("Unknown parent type: " + parent);
-    }
 }

--- a/src/dom/utils.ts
+++ b/src/dom/utils.ts
@@ -2,6 +2,7 @@ import { ContentView } from 'tns-core-modules/ui/content-view';
 import { View } from 'tns-core-modules/ui/core/view';
 import { LayoutBase } from 'tns-core-modules/ui/layouts/layout-base';
 
+import NativeElementNode from './native/NativeElementNode';
 import ViewNode from './nodes/ViewNode';
 
 export function isView(view) {
@@ -40,15 +41,12 @@ export function insertChild(parentNode: ViewNode, childNode: ViewNode, atIndex =
 
     if (parentView instanceof LayoutBase) {
         if (atIndex >= 0) {
+            // our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
+            // we recalculate the index required for the insert operation buy only including native element nodes in the count
             //our dom includes "textNode" and "commentNode" which does not appear in the nativeview's children.
             //we recalculate the index required for the insert operation buy only including native element nodes in the count
-            // let nativeIndex = parentNode.childNodes
-            //     .filter((e) => {
-            //         const instance = e instanceOf ElementNode';
-            //         return instance;
-            //     })
-            //     .indexOf(childNode);
-            parentView.insertChild(childView, atIndex);
+            let nativeIndex = parentNode.childNodes.filter((e) => e instanceof NativeElementNode).indexOf(childNode);
+            parentView.insertChild(childView, nativeIndex);
         } else {
             parentView.addChild(childView);
         }


### PR DESCRIPTION
I noticed that if you had an `if` block in your template as any element other than the last one, and it went from false to true the nodes inside would be added to the end instead of in the correct location.

The fix was to use the insertChild & removeChild from the NativeElementNode class - which correctly filters the child nodes https://github.com/bakerac4/glimmer-native/blob/master/src/dom/native/NativeElementNode.ts#L341