### PR TITLE
Modal close crash

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,8 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/dist/src/dom/native/ListViewElement.js
+++ b/dist/src/dom/native/ListViewElement.js
@@ -49,7 +49,7 @@ export default class ListViewElement extends NativeElementNode {
             const cursor = { element: wrapper, nextSibling: null };
             let component = Compilable(template.args.src);
             const compiled = component.compile(Application.context);
-            let componentInstance = Application._renderComponent(null, cursor, compiled, Object.assign(Object.assign({}, template.args), { item }));
+            let componentInstance = Application._renderComponent(null, cursor, compiled, Object.assign({}, template.args, { item }));
             let nativeEl = wrapper.nativeView;
             nativeEl.__GlimmerComponent__ = componentInstance._meta.component;
             args.view = nativeEl;
@@ -59,7 +59,7 @@ export default class ListViewElement extends NativeElementNode {
             let componentInstance = args.view.__GlimmerComponent__;
             const oldState = componentInstance.state.value();
             // Update the state with the new item
-            componentInstance.update(Object.assign(Object.assign({}, oldState), { item }));
+            componentInstance.update(Object.assign({}, oldState, { item }));
         }
     }
     get itemTemplateComponent() {

--- a/dist/src/dom/native/RadListViewElement.js
+++ b/dist/src/dom/native/RadListViewElement.js
@@ -52,7 +52,7 @@ export default class RadListViewElement extends NativeElementNode {
             let componentInstance = args.view.__GlimmerComponent__;
             const oldState = componentInstance.state.value();
             // Update the state with the new item
-            componentInstance.update(Object.assign(Object.assign({}, oldState), { item }));
+            componentInstance.update(Object.assign({}, oldState, { item }));
         }
         else {
             console.log('got invalid update call with', args.index, args.view);

--- a/dist/src/glimmer/native-component-manager.d.ts
+++ b/dist/src/glimmer/native-component-manager.d.ts
@@ -27,7 +27,7 @@ export default class NativeComponentManager implements VMComponentManager<Compon
     didCreateElement(): void;
     didRenderLayout(bucket: ComponentStateBucket, bounds: Bounds): void;
     didCreate(bucket: ComponentStateBucket): void;
-    getTag(bucket: ComponentStateBucket): Tag;
+    getTag(bucket: ComponentStateBucket): import("@glimmer/reference").TagWrapper<import("@glimmer/reference").RevisionTag>;
     update(bucket: ComponentStateBucket): void;
     didUpdateLayout(): void;
     didUpdate(): void;

--- a/dist/src/glimmer/navigation.js
+++ b/dist/src/glimmer/navigation.js
@@ -1,9 +1,8 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -76,7 +75,7 @@ export function navigate(componentName, model, options) {
         element.nativeView.on('navigatingFrom', function (args) {
             onNavigatedFrom(args, element);
         });
-        target.navigate(Object.assign(Object.assign({}, options), { create: () => {
+        target.navigate(Object.assign({}, options, { create: () => {
                 return element.nativeView;
             } }));
     }
@@ -96,7 +95,7 @@ export function navigate(componentName, model, options) {
                 }
             };
             element.nativeView.on('navigatedFrom', handler);
-            topmost().navigate(Object.assign(Object.assign({}, options), { create: () => {
+            topmost().navigate(Object.assign({}, options, { create: () => {
                     return element.nativeView;
                 } }));
             console.log('New page rendered');
@@ -173,12 +172,14 @@ export function showModal(componentName, model, options) {
             }
         };
         modalStack.push(element);
-        modalLauncher.showModal(element.nativeView, Object.assign(Object.assign({}, options), { context: model, closeCallback }));
+        modalLauncher.showModal(element.nativeView, Object.assign({}, options, { context: model, closeCallback }));
     });
 }
 export function closeModal(returnValue) {
     let modalPageInstanceInfo = modalStack.pop();
-    modalPageInstanceInfo.nativeView.closeModal(returnValue);
+    if (modalPageInstanceInfo) {
+        modalPageInstanceInfo.nativeView.closeModal(returnValue);
+    }
 }
 class Navigation {
     constructor() {

--- a/dist/src/glimmer/result.d.ts
+++ b/dist/src/glimmer/result.d.ts
@@ -6,7 +6,7 @@ export default class NativeComponentResult {
     state: UpdatableReference<{}>;
     runtime: AotRuntimeContext;
     constructor(name: string, result: RenderResult, state: UpdatableReference<{}>, runtime: AotRuntimeContext);
-    update(state: any): void;
+    update(state: any): Promise<void>;
     toJSON(): {
         GlimmerDebug: string;
     };

--- a/dist/src/glimmer/result.js
+++ b/dist/src/glimmer/result.js
@@ -1,3 +1,11 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 export default class NativeComponentResult {
     constructor(name, result, state, runtime) {
         this.name = name;
@@ -6,10 +14,12 @@ export default class NativeComponentResult {
         this.runtime = runtime;
     }
     update(state) {
-        this.state.update(state);
-        this.runtime.env.begin();
-        this.result.rerender();
-        this.runtime.env.commit();
+        return __awaiter(this, void 0, void 0, function* () {
+            this.state.update(state);
+            this.runtime.env.begin();
+            yield this.result.rerender();
+            this.runtime.env.commit();
+        });
     }
     toJSON() {
         return { GlimmerDebug: `<component-result name="${this.name}">` };

--- a/src/glimmer/navigation.ts
+++ b/src/glimmer/navigation.ts
@@ -209,7 +209,9 @@ export function showModal<T>(componentName: string, model: any, options?: ShowMo
 
 export function closeModal(returnValue?): void {
     let modalPageInstanceInfo = modalStack.pop();
-    modalPageInstanceInfo.nativeView.closeModal(returnValue);
+    if (modalPageInstanceInfo) {
+        modalPageInstanceInfo.nativeView.closeModal(returnValue);
+    }
 }
 
 class Navigation {


### PR DESCRIPTION
It looks like we need to guard against the modal instance from not existing, as if for example a user quickly triggers multiple `closeModal()` executions on the current modal, the second one causes the app to crash with this error:
```
Terminating app due to uncaught exception 'NativeScript encountered a fatal error: TypeError: undefined is not an object (evaluating 'modalPageInstanceInfo.nativeView')
```

@bakerac4 do I need to build the project or anything, in order to have these changes put in `dist/`?